### PR TITLE
Add dev standards

### DIFF
--- a/Module-03.md
+++ b/Module-03.md
@@ -4,7 +4,7 @@
 
 ## Getting Started
 
-Prior to completing the module below you'll need to review the [Generation Tux Development Standards](https://github.com/generationtux/training-modules/blob/master/development-standards.md).
+Prior to completing the module below you'll need to review the [Generation Tux Development Standards](development-standards.md).
 
 ***
 

--- a/Module-03.md
+++ b/Module-03.md
@@ -4,7 +4,7 @@
 
 ## Getting Started
 
-Prior to completing the module below you'll need to review the [Realpage Development Standards](https://github.com/realpage/development-standards).
+Prior to completing the module below you'll need to review the [Generation Tux Development Standards](https://github.com/generationtux/training-modules/blob/master/development-standards.md).
 
 ***
 

--- a/Module-04.md
+++ b/Module-04.md
@@ -9,6 +9,7 @@ Prior to completing the module below it is highly recommended that you look at t
 - [Test-Driven PHP](http://net.tutsplus.com/sessions/test-driven-php/)
 - [How to Write Testable and Maintainable Code in PHP](http://net.tutsplus.com/tutorials/php/how-to-write-testable-and-maintainable-code-in-php/)
 - [Laracasts: Testing Jargon](https://laracasts.com/series/testing-jargon)
+- [Laracasts: Testing Laravel](https://laracasts.com/series/phpunit-testing-in-laravel)
 - [Easier Testing With Mockery](https://tutsplus.com/tutorial/easier-testing-with-mockery/)
 
 ***

--- a/README.md
+++ b/README.md
@@ -10,17 +10,17 @@ This branch of the training modules repository is specific to PHP web developmen
 
 ## Table Of Contents
 
-1. [Git Basics](https://github.com/RealpageLouisville/training-web-modules/blob/master/Module-01.md)
-2. [Programming Basics with PHP](https://github.com/RealpageLouisville/training-web-modules/blob/master/Module-02.md)
-3. [PHP Coding Standards](https://github.com/RealpageLouisville/training-web-modules/blob/master/Module-03.md)
-4. [Test Driven Development (TDD)](https://github.com/RealpageLouisville/training-web-modules/blob/master/Module-04.md)
-5. [PHP Documentation Standards](https://github.com/RealpageLouisville/training-web-modules/blob/master/Module-05.md)
-6. [Advanced TDD](https://github.com/RealpageLouisville/training-web-modules/blob/master/Module-06.md)
-7. [Architecture](https://github.com/RealpageLouisville/training-web-modules/blob/master/Module-07.md)
+1. [Git Basics](Module-01.md)
+2. [Programming Basics with PHP](Module-02.md)
+3. [PHP Coding Standards](Module-03.md)
+4. [Test Driven Development (TDD)](Module-04.md)
+5. [PHP Documentation Standards](Module-05.md)
+6. [Advanced TDD](Module-06.md)
+7. [Architecture](Module-07.md)
 8. Depending on the type of work you're doing, choose either the Laravel or Lumen module.
-  * a. [Laravel PHP Framework](https://github.com/RealpageLouisville/training-web-modules/blob/master/Module-08a.md) - Full php framework, includes front-end asset handling (gulp, elixir, etc.)
-  * b. [Lumen PHP Framework](https://github.com/RealpageLouisville/training-web-modules/blob/master/Module-08b.md) - Micro-framework by Laravel intended for microservices and APIs
-9. [REST](https://github.com/RealpageLouisville/training-web-modules/blob/master/Module-09.md)
-10. [Reusable Code in Packages](https://github.com/RealpageLouisville/training-web-modules/blob/master/Module-10.md)
-11. [Docker](https://github.com/RealpageLouisville/training-web-modules/blob/master/Module-11.md)
-12. [Docker Compose](https://github.com/RealpageLouisville/training-web-modules/blob/master/Module-12.md)
+  * a. [Laravel PHP Framework](Module-08a.md) - Full php framework, includes front-end asset handling (gulp, elixir, etc.)
+  * b. [Lumen PHP Framework](Module-08b.md) - Micro-framework by Laravel intended for microservices and APIs
+9. [REST](Module-09.md)
+10. [Reusable Code in Packages](Module-10.md)
+11. [Docker](Module-11.md)
+12. [Docker Compose](Module-12.md)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This branch of the training modules repository is specific to PHP web developmen
 
 ## Table Of Contents
 
+0. [Generation Tux Development Standards](development-standards.md)
 1. [Git Basics](Module-01.md)
 2. [Programming Basics with PHP](Module-02.md)
 3. [PHP Coding Standards](Module-03.md)

--- a/development-standars.md
+++ b/development-standars.md
@@ -1,0 +1,25 @@
+
+# Generation Tux Development Standards
+
+## Code
+
+ * Must follow all [accepted PSR standards](http://www.php-fig.org/psr/#accepted)
+ * Must follow [SOLID principles](https://laracasts.com/series/solid-principles-in-php). (Ask an engineer for Laracast credentials)
+ * Must not be pulled into mainline branches until it has gone through code review
+ * Should indicate _what_ is happening, comments should indicate _why_
+
+### Code Review
+
+Reviewers must verify the standards in this document are being followed in addition to other [code review best practices](http://kevinlondon.com/2015/05/05/code-review-best-practices.html).
+
+ * Must be reviewed by the author first
+ * Must be reviewed by at least one other member of the team (crucial for knowledge sharing)
+
+## Testing
+
+A developer should be able to check out the project, make a change, and if the tests pass be confident their change could be deployed to production.
+
+ * Tests should be automated, running in a CI environment on every pull request
+ * Requirements for a feature should be scoped out by the team prior to beginning work on that feature
+ * Unit test coverage should be 100% for domain logic, leaving integration points with the framework (such as controllers, service providers, etc.) to be covered by other types of tests described below
+ * Functional, integration and acceptance testing coverage should be whatever it needs to be to ensure the application is working correctly


### PR DESCRIPTION
@brianwebb01 the dev standards are almost a copy of the realpage dev standards repo, but I felt it was redundant to create a repo dedicated to it, so I just added it here. Also added a couple more laracast tutorial mentions after looking over everything at a quick glance. Will create more PR's if I think of anything else that was helpful when starting out.